### PR TITLE
fix: support slotted inputs properly

### DIFF
--- a/src/vaadin-custom-field-mixin.html
+++ b/src/vaadin-custom-field-mixin.html
@@ -143,8 +143,7 @@
 
     __getInputsFromSlot() {
       const isInput = (node => node.validate || node.checkValidity);
-      const slottedElements = Polymer.FlattenedNodesObserver.getFlattenedNodes(this.$.slot)
-        .filter(node => node.nodeType === Node.ELEMENT_NODE);
+      const slottedElements = this.$.slot.assignedNodes({flatten: true}).filter(node => node.nodeType === Node.ELEMENT_NODE);
       const inputs = [];
       slottedElements.forEach(elem => {
         if (isInput(elem)) {

--- a/src/vaadin-custom-field-mixin.html
+++ b/src/vaadin-custom-field-mixin.html
@@ -1,3 +1,5 @@
+<link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
+
 <script>
   /**
    * @namespace Vaadin
@@ -67,18 +69,23 @@
 
     connectedCallback() {
       super.connectedCallback();
-      this.__observeChildrenInputsChange();
+      if (this.__observer) {
+        this.__observer.connect();
+      }
     }
 
     disconnectedCallback() {
       super.disconnectedCallback();
-      this.__childMutationObserver.disconnect();
+      this.__observer.disconnect();
     }
 
     ready() {
       super.ready();
 
-      this.__setInputsFromChildNodes();
+      this.__setInputsFromSlot();
+      this.__observer = new Polymer.FlattenedNodesObserver(this.$.slot, () => {
+        this.__setInputsFromSlot();
+      });
 
       this.addEventListener('keydown', e => {
         if (e.keyCode === 9) {
@@ -113,16 +120,6 @@
       this.inputs && this.inputs[0].focus();
     }
 
-    __observeChildrenInputsChange() {
-      const mutationObserverConfig = {
-        'childList': true,
-        'subtree': true
-      };
-
-      this.__childMutationObserver = new MutationObserver(this.__setInputsFromChildNodes.bind(this));
-      this.__childMutationObserver.observe(this, mutationObserverConfig);
-    }
-
     __updateValue(e) {
       // Stop native change events
       e && e.stopPropagation();
@@ -144,9 +141,24 @@
       this.__settingValue = false;
     }
 
-    __setInputsFromChildNodes() {
-      const inputs = Array.from(this.querySelectorAll('*')).filter(node => node.validate || node.checkValidity);
-      this._setInputs(inputs);
+    __getInputsFromSlot() {
+      const isInput = (node => node.validate || node.checkValidity);
+      const slottedElements = Polymer.FlattenedNodesObserver.getFlattenedNodes(this.$.slot)
+        .filter(node => node.nodeType === Node.ELEMENT_NODE);
+      const inputs = [];
+      slottedElements.forEach(elem => {
+        if (isInput(elem)) {
+          inputs.push(elem);
+        } else {
+          const newInputs = Array.from(elem.querySelectorAll('*')).filter(isInput);
+          inputs.push(...newInputs);
+        }
+      });
+      return inputs;
+    }
+
+    __setInputsFromSlot() {
+      this._setInputs(this.__getInputsFromSlot());
       this.__setValue();
     }
 

--- a/test/custom-field-slot-test.html
+++ b/test/custom-field-slot-test.html
@@ -47,20 +47,36 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="nested-deep">
+    <template>
+      <x-field>
+        <div>
+          <div>
+            <input type="text">
+            <input type="number">
+          </div>
+        </div>
+      </x-field>
+    </template>
+  </test-fixture>
+
   <script>
-    ['default', 'nested'].forEach(set => {
+    ['default', 'nested', 'nested-deep'].forEach(set => {
       describe(`slot updates (${set})`, function() {
         let parent, customField, inputElement;
 
         beforeEach(function() {
           // 'parent' is the element to add and remove inputs to/from for testing
-          parent = fixture(set);
+          const root = fixture(set);
           if (set === 'nested') {
-            // parent = <x-field>
-            customField = parent.$.customField;
+            parent = root; // <x-field>
+            customField = root.$.customField; // <custom-field>
+          } else if (set === 'nested-deep') {
+            parent = root.firstElementChild.firstElementChild; // inner <div>
+            customField = root.$.customField; // <custom-field>
           } else {
-            // parent and customField are both just the <custom-field>
-            customField = parent;
+            parent = root; // <custom-field>
+            customField = root; // <custom-field>
           }
           inputElement = window.document.createElement('input');
         });

--- a/test/custom-field-slot-test.html
+++ b/test/custom-field-slot-test.html
@@ -11,6 +11,24 @@
 </head>
 
 <body>
+  <dom-module id="x-field">
+    <template>
+      <vaadin-custom-field id="customField">
+        <slot></slot>
+      </vaadin-custom-field>
+    </template>
+    <script>
+      window.addEventListener('WebComponentsReady', () => {
+        class XField extends Polymer.Element {
+          static get is() {
+            return 'x-field';
+          }
+        }
+        customElements.define(XField.is, XField);
+      });
+    </script>
+  </dom-module>
+
   <test-fixture id="default">
     <template>
       <vaadin-custom-field>
@@ -20,59 +38,78 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="nested">
+    <template>
+      <x-field>
+        <input type="text">
+        <input type="number">
+      </x-field>
+    </template>
+  </test-fixture>
+
   <script>
-    describe('slot updates', function() {
-      var customField, inputElement;
+    ['default', 'nested'].forEach(set => {
+      describe(`slot updates (${set})`, function() {
+        let parent, customField, inputElement;
 
-      beforeEach(function() {
-        customField = fixture('default');
-        inputElement = window.document.createElement('input');
-      });
-
-      it('should add new input to the input list when adding to the DOM', function(done) {
-        customField.appendChild(inputElement);
-        setTimeout(() => {
-          expect(customField.inputs.length).to.equal(3);
-          expect(customField.inputs[2]).to.eql(inputElement);
-          done();
+        beforeEach(function() {
+          // 'parent' is the element to add and remove inputs to/from for testing
+          parent = fixture(set);
+          if (set === 'nested') {
+            // parent = <x-field>
+            customField = parent.$.customField;
+          } else {
+            // parent and customField are both just the <custom-field>
+            customField = parent;
+          }
+          inputElement = window.document.createElement('input');
         });
-      });
 
-      it('should remove input from the input list when removing from the DOM', function(done) {
-        // Remove one of the inputs from the DOM
-        customField.removeChild(customField.children[1]);
-        setTimeout(() => {
-          expect(customField.inputs.length).to.equal(1);
-          done();
-        });
-      });
-
-      describe('value property', function() {
-
-        it('should update value when input is added', function(done) {
-          inputElement.value = 'foo';
-          customField.appendChild(inputElement);
+        it('should add new input to the input list when adding to the DOM', function(done) {
+          parent.appendChild(inputElement);
           setTimeout(() => {
-            // Two empty spaces are from empty inputs
-            expect(customField.value).to.equal('\t\tfoo');
+            expect(customField.inputs.length).to.equal(3);
+            expect(customField.inputs[2]).to.eql(inputElement);
             done();
           });
         });
 
-        it('should update value when input is removed', function(done) {
-          const secondInput = customField.children[1];
-          secondInput.value = '1';
-          dispatchChange(secondInput);
-          expect(customField.value).to.equal('\t1');
-          customField.removeChild(secondInput);
+        it('should remove input from the input list when removing from the DOM', function(done) {
+          // Remove one of the inputs from the DOM
+          parent.removeChild(parent.children[1]);
           setTimeout(() => {
-            expect(customField.value).to.equal('');
+            expect(customField.inputs.length).to.equal(1);
             done();
           });
         });
 
-      });
+        describe('value property', function() {
 
+          it('should update value when input is added', function(done) {
+            inputElement.value = 'foo';
+            parent.appendChild(inputElement);
+            setTimeout(() => {
+              // Two empty spaces are from empty inputs
+              expect(customField.value).to.equal('\t\tfoo');
+              done();
+            });
+          });
+
+          it('should update value when input is removed', function(done) {
+            const secondInput = parent.children[1];
+            secondInput.value = '1';
+            dispatchChange(secondInput);
+            expect(customField.value).to.equal('\t1');
+            parent.removeChild(secondInput);
+            setTimeout(() => {
+              expect(customField.value).to.equal('');
+              done();
+            });
+          });
+
+        });
+
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Inputs are now properly detected even through nested slots.

Fixes #48.

NOTE: Visual tests are failing in master currently so you can ignore visual tests while reviewing this. That will be addressed by #49 (which is waiting for release of vaadin/vaadin-text-field#418).