### PR TITLE
Fix container to have 100% width

### DIFF
--- a/src/vaadin-custom-field.html
+++ b/src/vaadin-custom-field.html
@@ -29,6 +29,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       .container {
+        width: 100%;
         display: flex;
         flex-direction: column;
       }


### PR DESCRIPTION
This change is needed for vaadin-custom-field to work with more complex content, especially when used in Java.

Fixes: https://github.com/vaadin/vaadin-custom-field/issues/45

Fixes: https://github.com/vaadin/vaadin-custom-field/issues/28

Fixes: https://github.com/vaadin/vaadin-custom-field-flow/issues/18