### PR TITLE
feat: prepare for TS defs generation

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,12 @@
+export type CustomFieldParseValueFn = (
+  value: any
+) => Array<any>;
+
+export type CustomFieldFormatValueFn = (
+  inputValues: Array<any>
+) => any;
+
+export type CustomFieldI18n = {
+  parseValue: CustomFieldParseValueFn;
+  formatValue: CustomFieldFormatValueFn;
+};

--- a/bower.json
+++ b/bower.json
@@ -26,8 +26,8 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2"
   },
@@ -44,8 +44,5 @@
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.1.0",
     "vaadin-list-box": "vaadin/vaadin-list-box#^1.3.0"
-  },
-  "resolutions": {
-    "vaadin-element-mixin": "^2.0.0"
   }
 }

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,14 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "CustomFieldI18n"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-custom-field.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/src/vaadin-custom-field-mixin.html
+++ b/src/vaadin-custom-field-mixin.html
@@ -15,6 +15,7 @@
       return {
         /**
          * Array of available input nodes
+         * @type {!Array<!HTMLElement> | undefined}
          */
         inputs: {
           type: Array,
@@ -47,7 +48,9 @@
              parseValue: value => {
                // returns the array of values from parsed value string.
              }
-          */
+         *
+         * @type {!CustomFieldI18n}
+         */
         i18n: {
           type: Object,
           value: () => {
@@ -62,11 +65,15 @@
           }
         },
 
+        /** @private */
         __errorId: String,
+
+        /** @private */
         __labelId: String
       };
     }
 
+    /** @protected */
     connectedCallback() {
       super.connectedCallback();
       if (this.__observer) {
@@ -74,11 +81,13 @@
       }
     }
 
+    /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
       this.__observer && this.__observer.disconnect();
     }
 
+    /** @protected */
     ready() {
       super.ready();
 
@@ -122,13 +131,14 @@
       this.__labelId = `${this.constructor.is}-label-${uniqueId}`;
     }
 
-    /*
-     * @private
-     */
     focus() {
       this.inputs && this.inputs[0] && this.inputs[0].focus();
     }
 
+    /**
+     * @param {!Event | undefined} e
+     * @protected
+     */
     __updateValue(e) {
       // Stop native change events
       e && e.stopPropagation();
@@ -144,13 +154,17 @@
       }));
     }
 
+    /** @private */
     __setValue() {
       this.__settingValue = true;
       this.value = this.i18n.formatValue.apply(this, [this.inputs.map(input => input.value)]);
       this.__settingValue = false;
     }
 
-    /* Like querySelectorAll('*') but also gets all elements through any nested slots recursively */
+    /**
+     * Like querySelectorAll('*') but also gets all elements through any nested slots recursively
+     * @private
+     */
     __queryAllAssignedElements(elem) {
       const result = [];
       let elements;
@@ -164,16 +178,19 @@
       return result;
     }
 
+    /** @private */
     __getInputsFromSlot() {
       const isInput = (node => node.validate || node.checkValidity);
       return this.__queryAllAssignedElements(this.$.slot).filter(isInput);
     }
 
+    /** @private */
     __setInputsFromSlot() {
       this._setInputs(this.__getInputsFromSlot());
       this.__setValue();
     }
 
+    /** @private */
     __valueChanged(value, oldValue) {
       if (this.__settingValue || !this.inputs) {
         return;

--- a/src/vaadin-custom-field-mixin.html
+++ b/src/vaadin-custom-field-mixin.html
@@ -131,14 +131,12 @@
       this.__labelId = `${this.constructor.is}-label-${uniqueId}`;
     }
 
+    /** @protected */
     focus() {
       this.inputs && this.inputs[0] && this.inputs[0].focus();
     }
 
-    /**
-     * @param {!Event | undefined} e
-     * @protected
-     */
+    /** @private */
     __updateValue(e) {
       // Stop native change events
       e && e.stopPropagation();

--- a/src/vaadin-custom-field.html
+++ b/src/vaadin-custom-field.html
@@ -110,6 +110,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * String used for the label element.
+             * @type {string}
              */
             label: {
               type: String,
@@ -144,6 +145,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * This property is set to true when the control value is invalid.
+             * @type {boolean}
              */
             invalid: {
               type: Boolean,
@@ -155,6 +157,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Error to show when the input value is invalid.
+             * @type {string}
              */
             errorMessage: {
               type: String,
@@ -171,10 +174,12 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
+        /** @private */
         __invalidChanged(invalid) {
           this.__setOrToggleAttribute('aria-invalid', invalid, this);
         }
 
+        /** @private */
         __toggleHasValue(value) {
           if (value !== null && value.trim() !== '') {
             this.setAttribute('has-value', '');
@@ -183,6 +188,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _labelChanged(label) {
           if (label !== '' && label != null) {
             this.setAttribute('has-label', '');
@@ -203,7 +209,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Returns true if the current inputs values satisfy all constraints (if any)
-         * @returns {boolean}
+         * @return {boolean}
          */
         checkValidity() {
           const invalidFields = this.inputs
@@ -217,6 +223,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return true;
         }
 
+        /** @private */
         __setOrToggleAttribute(name, value, node) {
           if (!name || !node) {
             return;
@@ -230,18 +237,21 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         __getActiveErrorId(invalid, errorMessage, errorId) {
           this.__setOrToggleAttribute('aria-describedby',
             (errorMessage && invalid ? errorId : undefined),
             this);
         }
 
+        /** @private */
         __getActiveLabelId(label, labelId) {
           this.__setOrToggleAttribute('aria-labelledby',
             (label ? labelId : undefined),
             this);
         }
 
+        /** @private */
         __getErrorMessageAriaHidden(invalid, errorMessage, errorId) {
           return (!(errorMessage && invalid ? errorId : undefined)).toString();
         }


### PR DESCRIPTION
Fixes #73 

Generated TypeScript definitions look like this:

## vaadin-custom-field.d.ts

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {CustomFieldMixin} from './vaadin-custom-field-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class CustomFieldElement extends
  ElementMixin(
  ThemableMixin(
  CustomFieldMixin(
  PolymerElement))) {

  label: string;
  name: string|null|undefined;
  required: boolean|null|undefined;
  value: string|null|undefined;
  invalid: boolean;
  errorMessage: string;

  validate(): boolean;
  checkValidity(): boolean;
}

declare global {

  interface HTMLElementTagNameMap {
    "vaadin-custom-field": CustomFieldElement;
  }
}

export {CustomFieldElement};
```

## vaadin-custom-field-mixin.d.ts

```ts
import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

export {CustomFieldMixin};

declare function CustomFieldMixin<T extends new (...args: any[]) => {}>(base: T): T & CustomFieldMixinConstructor;

interface CustomFieldMixinConstructor {
  new(...args: any[]): CustomFieldMixin;
}

export {CustomFieldMixinConstructor};

interface CustomFieldMixin {
  readonly inputs: HTMLElement[]|undefined;
  i18n: CustomFieldI18n;
  connectedCallback(): void;
  disconnectedCallback(): void;
  ready(): void;
  focus(): void;
  __updateValue(e: Event|undefined): void;
}

import {CustomFieldI18n} from '../@types/interfaces';
```

## interfaces.d.ts

```ts
export type CustomFieldParseValueFn = (
  value: any
) => Array<any>;

export type CustomFieldFormatValueFn = (
  inputValues: Array<any>
) => any;

export type CustomFieldI18n = {
  parseValue: CustomFieldParseValueFn;
  formatValue: CustomFieldFormatValueFn;
};
```