### PR TITLE
fix: replace any in TS defs with generics

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,12 +1,8 @@
-export type CustomFieldParseValueFn = (
-  value: any
-) => Array<any>;
+export type CustomFieldParseValueFn<T> = (value: T) => Array<T>;
 
-export type CustomFieldFormatValueFn = (
-  inputValues: Array<any>
-) => any;
+export type CustomFieldFormatValueFn<T> = (inputValues: Array<T>) => T;
 
 export type CustomFieldI18n = {
-  parseValue: CustomFieldParseValueFn;
-  formatValue: CustomFieldFormatValueFn;
+  parseValue: CustomFieldParseValueFn<string>;
+  formatValue: CustomFieldFormatValueFn<string>;
 };

--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,8 +1,8 @@
-export type CustomFieldParseValueFn<T> = (value: T) => Array<T>;
+export type CustomFieldParseValueFn = (value: string) => Array<unknown>;
 
-export type CustomFieldFormatValueFn<T> = (inputValues: Array<T>) => T;
+export type CustomFieldFormatValueFn = (inputValues: Array<unknown>) => string;
 
-export type CustomFieldI18n = {
-  parseValue: CustomFieldParseValueFn<string>;
-  formatValue: CustomFieldFormatValueFn<string>;
-};
+export interface CustomFieldI18n {
+  parseValue: CustomFieldParseValueFn;
+  formatValue: CustomFieldFormatValueFn;
+}


### PR DESCRIPTION
This should better describe our current API and allow developers to provide their own helpers while keeping type checking support, instead of disabling it completely with `any`.