### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-custom-field.html
+++ b/src/vaadin-custom-field.html
@@ -157,6 +157,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Error to show when the input value is invalid.
+             * @attr {string} error-message
              * @type {string}
              */
             errorMessage: {


### PR DESCRIPTION
Connected to vaadin/vaadin-core#257

Note, this is a PR for `1.2` branch. When cherry-picking it to master, we need to also include `helperText` property.