### PR TITLE
chore: add JSDoc for custom events [skip ci]

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -11,12 +11,12 @@ export interface CustomFieldI18n {
 /**
  * Fired when the `invalid` property changes.
  */
-export type CustomFieldInvalidChanged = CustomEvent<{ value: boolean; path: 'invalid' }>;
+export type CustomFieldInvalidChanged = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type CustomFieldValueChanged = CustomEvent<{ value: string; path: 'value' }>;
+export type CustomFieldValueChanged = CustomEvent<{ value: string }>;
 
 export interface CustomFieldElementEventMap {
   'invalid-changed': CustomFieldInvalidChanged;

--- a/src/vaadin-custom-field.d.ts
+++ b/src/vaadin-custom-field.d.ts
@@ -39,6 +39,9 @@ import { CustomFieldEventMap } from './interfaces';
  * `focused`    | Set when the field contains focus | :host
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ *
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class CustomFieldElement extends ElementMixin(ThemableMixin(CustomFieldMixin(HTMLElement))) {
   /**

--- a/src/vaadin-custom-field.js
+++ b/src/vaadin-custom-field.js
@@ -42,6 +42,9 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ *
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin


### PR DESCRIPTION
1. Added `@fires` annotations to enable VS Code lit-plugin code completion support.
2. Removed `path` from events typings as Polymer-specific and generally unused.