### PR TITLE
chore: align JSDoc, add missing events [skip ci]

### DIFF
--- a/src/vaadin-custom-field.d.ts
+++ b/src/vaadin-custom-field.d.ts
@@ -40,6 +40,8 @@ import { CustomFieldEventMap } from './interfaces';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} change - Fired when the user commits a value change for any of the internal inputs.
+ * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-custom-field.js
+++ b/src/vaadin-custom-field.js
@@ -42,6 +42,8 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} change - Fired when the user commits a value change for any of the internal inputs.
+ * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *


### PR DESCRIPTION
This PR aligns the list of events suggested by VSCode with those listed in the [API docs](https://cdn.vaadin.com/vaadin-custom-field/2.0.0-alpha1/#/elements/vaadin-custom-field#events).