### PR TITLE
chore: update minor version to 1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/vaadin-custom-field",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "vaadin-custom-field",
   "main": "vaadin-custom-field.html",
   "repository": "vaadin/vaadin-custom-field",

--- a/src/vaadin-custom-field.html
+++ b/src/vaadin-custom-field.html
@@ -108,7 +108,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return 'vaadin-custom-field';
         }
         static get version() {
-          return '1.3.1';
+          return '1.4.0';
         }
 
         static get properties() {


### PR DESCRIPTION
Since we introduced a [small](https://github.com/vaadin/vaadin-custom-field/pull/104) feature (`whitespace` theme), it is required to have a new minor version.
